### PR TITLE
Add multicore simulator

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,15 @@
+2014-10-29  Ola Jeppsson  <ola@adapteva.com>
+
+	* build-epiphany-sdk.sh: Download and build Epiphany multicore
+	simulator by default.
+	* build-toolchain.sh: Support building and installing the
+	multicore simulator so that it doesn't conflict with GDB from the
+	toolchain.
+	* component-versions: Track the Epiphany multicore simulator
+	branch.
+	* download-toolchain.sh: Add option to download multi-core
+	simulator.
+
 2014-10-28  Jeremy Bennett  <jeremy.bennett@embecosm.com>
 
 	* build-toolchain.sh: Remove RPATH functionality. Irrelevant to a

--- a/build-epiphany-sdk.sh
+++ b/build-epiphany-sdk.sh
@@ -161,9 +161,14 @@ else
 	sdk_clean_str=""
 fi
 
+# TODO: We only want multicore-sim for x86_64 but we don't have the
+# infrastructure for checking host arch in this file yet. However,
+# 'build-toolchain.sh' will emit a warning and refuse to build it for hosts
+# other than x86_64. So we'll rely on that for the time being.
+multicore_sim_str="--multicore-sim"
 
 if [ "$EPIPHANY_BUILD_TOOLCHAIN" != "no" ]; then
-	if ! ./download-toolchain.sh --clone; then
+	if ! ./download-toolchain.sh ${multicore_sim_str} --clone; then
 
 		printf "\nAborting...\n"
 		exit 1
@@ -171,7 +176,7 @@ if [ "$EPIPHANY_BUILD_TOOLCHAIN" != "no" ]; then
 
 	#Build the toolchain (this will take a while)
 	if ! ./build-toolchain.sh --install-dir-host ${EPIPHANY_HOME}/tools/${GNUNAME} \
-		${host_str} ${toolchain_clean_str}; then
+		${host_str} ${toolchain_clean_str} ${multicore_sim_str}; then
 		printf "The toolchain build failed!\n"
 		printf "\nAborting...\n"
 		exit 1

--- a/component-versions
+++ b/component-versions
@@ -30,6 +30,9 @@ gdb:epiphany-gdb-7.6
 newlib:epiphany-newlib-1.20-software-cache
 cgen:epiphany-cgen-1.1-software-cache
 
+# Epiphany Multicore simulator
+gdb-multicore-sim:epiphany-gdb-7.6-multicore-sim
+
 # At present we don't worry about the GCC infrastructure components being
 # pulled from git. Versions recorded as comments here.
 # gmp:gmp-4.3.2

--- a/download-toolchain.sh
+++ b/download-toolchain.sh
@@ -68,6 +68,15 @@
 #     infrastructure URL, which may be changed by the --infra-url option. By
 #     default all components are downloaded.
 
+# --multicore-sim | --no-multicore-sim
+
+#     Download, or (with the --no- prefix) don't download the GDB based
+#     experimental multi-core simulator.
+#     The components are downloaded from the
+#     infrastructure URL, which may be changed by the --infra-url option. By
+#     default all components are downloaded.
+
+
 # --help | -h
 
 #     Print out a brief help about this script and return with an error code.
@@ -299,6 +308,7 @@ do_mpc="--do-mpc"
 do_isl="--do-isl"
 do_cloog="--do-cloog"
 do_ncurses="--do-ncurses"
+do_multicore_sim="--multicore-sim"
 
 until
 opt=$1
@@ -361,6 +371,10 @@ case ${opt} in
 	do_ncurses="$1"
 	;;
 
+    --multicore-sim | --no-multicore-sim)
+	do_multicore_sim="$1"
+	;;
+
     ?*)
 	echo "Usage: ./download-toolchain [--force | --no-force]"
 	echo "                            [--clone | --download]"
@@ -372,6 +386,7 @@ case ${opt} in
 	echo "                            [--isl | --no-isl]"
 	echo "                            [--cloog | --no-cloog]"
 	echo "                            [--ncurses | --no-ncurses]"
+	echo "                            [--multicore-sim | --no-multicore-sim]"
 	echo "                            [--help | -h]"
 	exit 1
 	;;
@@ -448,6 +463,11 @@ if [ "${do_ncurses}" = "--do-ncurses" ]
 then
     other_component "ncurses" "ncurses-5.9" "tar.gz" \
 	"http://ftp.gnu.org/pub/gnu/ncurses" || res="fail"
+fi
+
+if [ "${do_multicore_sim}" = "--multicore-sim" ]
+then
+    github_tool gdb-multicore-sim epiphany-binutils-gdb epiphany-gdb-7.6-multicore-sim || res="fail"
 fi
 
 if [ "${res}" = "ok" ]


### PR DESCRIPTION
- build-epiphany-sdk.sh: Download and build Epiphany multicore simulator
  by default.
- build-toolchain.sh: Support building and installing the multicore
  simulator so that it doesn't conflict with GDB from the toolchain.
- component-versions: Track the Epiphany multicore simulator branch.
- download-toolchain.sh: Add option to download multi-core simulator.
