### PR TITLE
Use HTTPS for Git cloning

### DIFF
--- a/download-toolchain.sh
+++ b/download-toolchain.sh
@@ -232,7 +232,7 @@ github_tool () {
 
     if [ ${clone} = "true" ]
     then
-	clone_tool "${tool}" "git://github.com/adapteva/${repo}" "${branch}"
+	clone_tool "${tool}" "https://github.com/adapteva/${repo}" "${branch}"
     else
 	download_tool "${tool}" "https://github.com/adapteva/${repo}/archive" \
 	              "unzip" "${branch}.zip" "${repo}-${branch}"


### PR DESCRIPTION
In order to make the cloning of Git repos easier behind corporate firewalls, and similar sites where HTTP/HTTPS access to external sites is usually enabled.
